### PR TITLE
Allow to forward log4cxx log messages to the Python logging module

### DIFF
--- a/pylogging/pylogging.cpp
+++ b/pylogging/pylogging.cpp
@@ -121,6 +121,17 @@ namespace {
 		std::string const &domain,
 		log4cxx::LoggerPtr logger = log4cxx::Logger::getRootLogger())
 	{
+		// Check whether a logger for this domain was already added -- if yes,
+		// do nothing. It makes no sense to log to the same logging domain
+		// multiple times
+		for (log4cxx::AppenderPtr &ptr : logger->getAllAppenders()) {
+			log4cxx::PythonLoggingAppender *pyapp =
+				dynamic_cast<log4cxx::PythonLoggingAppender*>(&*ptr);
+			if (pyapp && pyapp->domain() == domain) {
+				return ptr;
+			}
+		}
+
 		log4cxx::AppenderPtr appender(new log4cxx::PythonLoggingAppender(domain));
 		logger->addAppender(appender);
 		return appender;

--- a/pylogging/pylogging.cpp
+++ b/pylogging/pylogging.cpp
@@ -16,6 +16,7 @@
 #include "logging_ctrl.h"
 #include "logger.h"
 #include "colorlayout.h"
+#include "python_logging_appender.h"
 
 using namespace boost::python;
 
@@ -114,6 +115,16 @@ namespace {
 		handler.activateOptions(pool);
 	}
 
+
+	/// adds a ConsoleAppender to the given logger
+	log4cxx::AppenderPtr logger_write_to_logging(
+		std::string const &domain,
+		log4cxx::LoggerPtr logger = log4cxx::Logger::getRootLogger())
+	{
+		log4cxx::AppenderPtr appender(new log4cxx::PythonLoggingAppender(domain));
+		logger->addAppender(appender);
+		return appender;
+	}
 }
 
 class PyWriter : public log4cxx::helpers::Writer
@@ -292,6 +303,12 @@ BOOST_PYTHON_MODULE(pylogging)
 
 	def("append_to_cout", logger_write_to_cout, (arg("logger") = log4cxx::Logger::getRootLogger()),
 	    "adds a ConsoleAppender to the given logger");
+
+	def("write_to_logging", logger_write_to_logging, (arg("domain"), arg("logger") = log4cxx::Logger::getRootLogger()),
+	    "adds a PythonLoggingAppender to the given logger");
+
+	def("append_to_logging", logger_write_to_logging, (arg("domain"), arg("logger") = log4cxx::Logger::getRootLogger()),
+	    "adds a PythonLoggingAppender to the given logger");
 
 	def("log_to_file", logger_log_to_file,
 			"Configure the logger to log everything above the given loglevel to a file");

--- a/pylogging/python_logging_appender.cpp
+++ b/pylogging/python_logging_appender.cpp
@@ -1,0 +1,135 @@
+/*
+ *  log4cxx Python Logging Appender
+ *  Copyright (C) 2016  Andreas Stöckel
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <iostream>
+
+#include <boost/python.hpp>
+
+#include "python_logging_appender.h"
+
+namespace log4cxx {
+
+/**
+ * Actual implementation of the PythonLoggingAppender. This class is responsible
+ * for actually sending the log messages to the Python "logging" module. This
+ * module is lazily loaded once the first log message is received.
+ */
+class PythonLoggingAppenderImpl {
+private:
+	std::string m_domain;
+	boost::python::object m_logger;
+
+	/**
+	 * Initializes the m_logger variable if this has not been done yet.
+	 */
+	void init()
+	{
+		// Abort if the logger has already been fetched
+		if (m_logger.ptr() != boost::python::object().ptr()) {
+			return;
+		}
+
+		// Place the domain name in the local variable dictionary
+		boost::python::dict locals;
+		locals["domain"] = m_domain;
+
+		// Fetch the logger
+		boost::python::exec(
+		    "import logging\nlogger = logging.getLogger(domain)\n",
+		    boost::python::object(), locals);
+		m_logger = locals["logger"];
+	}
+
+	/**
+	 * Lossily converts log4cxx loglevels to corresponding Python log levels.
+	 *
+	 * @param level is the log4cxx log level.
+	 * @return a corresponding Python log level.
+	 */
+	static int convert_level(int level)
+	{
+		if (level >= Level::FATAL_INT) {
+			return 50;  // CRITICAL
+		}
+		else if (level >= Level::ERROR_INT) {
+			return 40;  // ERROR
+		}
+		else if (level >= Level::WARN_INT) {
+			return 30;  // WARNING
+		}
+		else if (level >= Level::INFO_INT) {
+			return 20;  // INFO
+		}
+		else if (level >= Level::DEBUG_INT) {
+			return 10;  // DEBUG
+		}
+		return 10;  // DEBUG
+	}
+
+public:
+	PythonLoggingAppenderImpl(const std::string &domain) : m_domain(domain) {}
+
+	void append(const spi::LoggingEventPtr &event)
+	{
+		// Initialize logging
+		init();
+
+		// Place all variables in the local variable dictionary
+		boost::python::dict locals;
+		locals["logger"] = m_logger;
+		locals["level"] = convert_level(event->getLevel()->toInt());
+		locals["message"] = event->getMessage();
+
+		// Get the logger name, if it is empty, directly write to the logger
+		// obtained by init(), otherwise write to a child logger.
+		std::string logger_name = event->getLoggerName();
+		if (!logger_name.empty()) {
+			locals["context"] = logger_name;
+			boost::python::exec("logger.getChild(context).log(level, message);",
+			                    boost::python::object(), locals);
+		}
+		else {
+			boost::python::exec("logger.log(level, message);",
+			                    boost::python::object(), locals);
+		}
+	}
+
+	void close()
+	{
+		// Delete the reference to the logger
+		m_logger = boost::python::object();
+	}
+};
+
+PythonLoggingAppender::PythonLoggingAppender(const std::string &domain)
+    : m_impl(new PythonLoggingAppenderImpl(domain))
+{
+}
+
+PythonLoggingAppender::~PythonLoggingAppender()
+{
+	// Do nothing here, only needed for the unique_ptr to be properly deleted
+}
+
+void PythonLoggingAppender::append(const spi::LoggingEventPtr &event,
+                                   log4cxx::helpers::Pool &)
+{
+	m_impl->append(event);
+}
+
+void PythonLoggingAppender::close() { m_impl->close(); }
+}

--- a/pylogging/python_logging_appender.cpp
+++ b/pylogging/python_logging_appender.cpp
@@ -126,6 +126,8 @@ public:
 		// Delete the reference to the logger
 		m_logger = boost::python::object();
 	}
+
+	const std::string &domain() const { return m_domain; }
 };
 
 PythonLoggingAppender::PythonLoggingAppender(const std::string &domain)
@@ -145,4 +147,9 @@ void PythonLoggingAppender::append(const spi::LoggingEventPtr &event,
 }
 
 void PythonLoggingAppender::close() { m_impl->close(); }
+
+const std::string &PythonLoggingAppender::domain() const
+{
+	return m_impl->domain();
+}
 }

--- a/pylogging/python_logging_appender.h
+++ b/pylogging/python_logging_appender.h
@@ -82,5 +82,10 @@ public:
 	 * class does not require a layout manager.
 	 */
 	bool requiresLayout() const override { return false; }
+
+	/**
+	 * Returns the "domain" string given in the constructor.
+	 */
+	const std::string &domain() const;
 };
 }

--- a/pylogging/python_logging_appender.h
+++ b/pylogging/python_logging_appender.h
@@ -1,0 +1,86 @@
+/*
+ *  log4cxx Python Logging Appender
+ *  Copyright (C) 2016  Andreas Stöckel
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/**
+ * @file python_logging_appender.hpp
+ *
+ * This file contains a simple appender class which forwards log4cxx log
+ * messages to the Python logging module via boost::python. This allows central
+ * handling of logging.
+ *
+ * @author Andreas Stöckel
+ */
+
+#include <memory>
+#include <string>
+
+#include <log4cxx/appenderskeleton.h>
+
+namespace log4cxx {
+/*
+ * Forward declarations.
+ */
+class PythonLoggingAppenderImpl;
+
+/**
+ * Implements an adapter class which write log4cxx events to the Python
+ * "logging" class. Note that boost::python needs to be initialized before this
+ * class is used.
+ */
+class PythonLoggingAppender : public AppenderSkeleton {
+private:
+	std::unique_ptr<PythonLoggingAppenderImpl> m_impl;
+
+protected:
+	/**
+	 * Called whenever a log message is received. Forwards the log message to
+	 * Python.
+	 */
+	void append(const spi::LoggingEventPtr &event,
+	            log4cxx::helpers::Pool &) override;
+
+public:
+	/**
+	 * Constructor of the PythonLoggingAppender class.
+	 *
+	 * @param domain is the name of the Python logger to which log messages
+	 * should be written. Per default an empty string is passed, which
+	 * corresponds to the root logger.
+	 */
+	PythonLoggingAppender(const std::string &domain = std::string());
+
+	/**
+	 * Destructor of the PythonLoggingAppender class. Cleans up the internal
+	 * implementation.
+	 */
+	~PythonLoggingAppender() override;
+
+	/**
+	 * Releases any pointers at Python objects.
+	 */
+	void close() override;
+
+	/**
+	 * Used internally by log4cxx, indicates that the PythonLoggingAppender
+	 * class does not require a layout manager.
+	 */
+	bool requiresLayout() const override { return false; }
+};
+}

--- a/pylogging/test_pylogging.py
+++ b/pylogging/test_pylogging.py
@@ -367,5 +367,34 @@ log4j.appender.A1.layout.PrintLocation=true
             {'msg': 'msg5', 'levelno': 10, 'name': 'root.test2.test3'}
         ], records)
 
+    def test_append_to_logging_multiple_calls(self):
+        import logging
+        records = []
+        class Handler(logging.Handler):
+            def emit(self, record):
+                records.append({
+                    "name": record.name,
+                    "msg": record.msg,
+                    "levelno": record.levelno
+                })
+        logging.getLogger("").addHandler(Handler())
+
+        # Log messages to the "root" logger
+        logger.append_to_logging("root")
+        logger.append_to_logging("root")
+        logger.append_to_logging("root")
+        logger.append_to_logging("root2")
+        logger.append_to_logging("root2")
+        logger.append_to_logging("root2")
+
+        # The message should only appear one time for each logger instead of
+        # multiple times
+        logger1 = logger.get("test1");
+        logger1.FATAL("msg1")
+        self.assertEqual([
+            {'msg': 'msg1', 'levelno': 50, 'name': 'root.test1'},
+            {'msg': 'msg1', 'levelno': 50, 'name': 'root2.test1'},
+        ], records)
+
 if __name__ == '__main__':
     unittest.main()

--- a/pylogging/test_pylogging.py
+++ b/pylogging/test_pylogging.py
@@ -304,5 +304,68 @@ log4j.appender.A1.layout.PrintLocation=true
             expected = "".join(loglines)
             self.assertEqual(expected, f.read())
 
+    def test_append_to_logging(self):
+        # Store all Python logging messages in the "records" list
+        import logging
+        records = []
+        class Handler(logging.Handler):
+            def emit(self, record):
+                records.append({
+                    "name": record.name,
+                    "msg": record.msg,
+                    "levelno": record.levelno
+                })
+        logging.getLogger("").addHandler(Handler())
+
+        # Log messages to the "root" logger
+        logger.append_to_logging("root")
+        self.assertEqual(1, logger.get_root()._get_number_of_appenders())
+
+        # Create two test loggers
+        logger1 = logger.get("test1");
+        logger.set_loglevel(logger1, logger.LogLevel.TRACE)
+        logger2 = logger.get("test2");
+        logger3 = logger.get("test2.test3");
+
+        logger1.FATAL("msg1")
+        logger1.ERROR("msg2")
+        logger1.WARN("msg3")
+        logger1.INFO("msg4")
+        logger1.DEBUG("msg5")
+        logger1.TRACE("msg6")
+
+        logger2.FATAL("msg1")
+        logger2.ERROR("msg2")
+        logger2.WARN("msg3")
+        logger2.INFO("msg4")
+        logger2.DEBUG("msg5")
+        logger2.TRACE("msg6")
+
+        logger3.FATAL("msg1")
+        logger3.ERROR("msg2")
+        logger3.WARN("msg3")
+        logger3.INFO("msg4")
+        logger3.DEBUG("msg5")
+        logger3.TRACE("msg6")
+
+        self.assertEqual([
+            {'msg': 'msg1', 'levelno': 50, 'name': 'root.test1'},
+            {'msg': 'msg2', 'levelno': 40, 'name': 'root.test1'},
+            {'msg': 'msg3', 'levelno': 30, 'name': 'root.test1'},
+            {'msg': 'msg4', 'levelno': 20, 'name': 'root.test1'},
+            {'msg': 'msg5', 'levelno': 10, 'name': 'root.test1'},
+            {'msg': 'msg6', 'levelno': 10, 'name': 'root.test1'},
+            {'msg': 'msg1', 'levelno': 50, 'name': 'root.test2'},
+            {'msg': 'msg2', 'levelno': 40, 'name': 'root.test2'},
+            {'msg': 'msg3', 'levelno': 30, 'name': 'root.test2'},
+            {'msg': 'msg4', 'levelno': 20, 'name': 'root.test2'},
+            {'msg': 'msg5', 'levelno': 10, 'name': 'root.test2'},
+            {'msg': 'msg1', 'levelno': 50, 'name': 'root.test2.test3'},
+            {'msg': 'msg2', 'levelno': 40, 'name': 'root.test2.test3'},
+            {'msg': 'msg3', 'levelno': 30, 'name': 'root.test2.test3'},
+            {'msg': 'msg4', 'levelno': 20, 'name': 'root.test2.test3'},
+            {'msg': 'msg5', 'levelno': 10, 'name': 'root.test2.test3'}
+        ], records)
+
 if __name__ == '__main__':
     unittest.main()

--- a/pylogging/wscript
+++ b/pylogging/wscript
@@ -29,6 +29,7 @@ def build(bld):
             use = ['BOOST4PYLOGGING', 'logger_obj'],
             install_path = '${PREFIX}/lib',
             post_task = 'pyloggingtest',
+            cxxflags=['-std=c++11'],
     )
 
     bld.install_files(

--- a/pylogging/wscript
+++ b/pylogging/wscript
@@ -24,7 +24,7 @@ def build(bld):
     bld(
             target = 'pylogging',
             features = 'cxx cxxshlib pyembed pyext',
-            source = 'pylogging.cpp',
+            source = ['pylogging.cpp', 'python_logging_appender.cpp'],
             export_includes = '.',
             use = ['BOOST4PYLOGGING', 'logger_obj'],
             install_path = '${PREFIX}/lib',

--- a/pylogging/wscript
+++ b/pylogging/wscript
@@ -21,12 +21,24 @@ def configure(cfg):
 
 def build(bld):
     bld.recurse('..')
+
+    bld.shlib(
+            target = 'logger_cxx2py',
+            features = 'pyembed',
+            name   = 'logger_cxx2py',
+            source = 'python_logging_appender.cpp',
+            export_includes = '.',
+            use = ['LOG4CXX', 'BOOST4PYLOGGING'],
+            install_path = '${PREFIX}/lib',
+            cxxflags=['-std=c++11'],
+    )
+
     bld(
             target = 'pylogging',
             features = 'cxx cxxshlib pyembed pyext',
-            source = ['pylogging.cpp', 'python_logging_appender.cpp'],
+            source = 'pylogging.cpp',
             export_includes = '.',
-            use = ['BOOST4PYLOGGING', 'logger_obj'],
+            use = ['BOOST4PYLOGGING', 'logger_obj', 'logger_cxx2py'],
             install_path = '${PREFIX}/lib',
             post_task = 'pyloggingtest',
             cxxflags=['-std=c++11'],


### PR DESCRIPTION
This pull request adds a new function `logger_write_to_logging` to the `pylogging` module which allows to forward all log4cxx log messages to the Python `logging` module. This is particularly useful, as this allows to finally unify log handling for all PyNN backends, which usually just log to the "pyNN" logger instance obtained from the logging module.
